### PR TITLE
MyServerCs: Enable connecting to an already running elevated server

### DIFF
--- a/MyServerCs/MyServerCs.csproj
+++ b/MyServerCs/MyServerCs.csproj
@@ -18,6 +18,12 @@
   <PropertyGroup>
     <Win32Resource>$(SolutionDir)$(Platform)\$(Configuration)\MyInterfaces.res</Win32Resource>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DefineConstants>$(DefineConstants);ENABLE_CONNECT_TO_ELEVATED</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DefineConstants>$(DefineConstants);ENABLE_CONNECT_TO_ELEVATED</DefineConstants>
+  </PropertyGroup>
 
   <Target Name="ServerUsage" AfterTargets="Build" DependsOnTargets="AssignTargetPaths">
     <Message Importance="High" Text="%0a************************************%0a*** $(MSBuildProjectName) usage instructions ***%0a************************************" />


### PR DESCRIPTION
Add `AppID` registry keys with explicit `RunAs="Interactive User"` to make the OS allow connection to already running COM servers with different security elevation under the same user account.

This will enable the following scenarios:
* Enable a non-elevated client to connect to an already running elevated server.
* Enable an elevated client to connect to an already running non-elevated server.

Limitations:
* The `AppID` `RunAs` parameter will need to be changed if one wants to connect to an existing COM server running under a _different_ user account.
* The MyServerCpp project have not yet been extended with the same AppID RunAs settings.

Documentation: [RunAs](https://learn.microsoft.com/en-us/windows/win32/com/runas)