### PR TITLE
Run MyServerCs under "LocalService" account

### DIFF
--- a/MyServerCpp/Main.cpp
+++ b/MyServerCpp/Main.cpp
@@ -19,7 +19,17 @@ MyserverModule _AtlModule;
 
 // EXE Entry Point
 int wmain(int /*argc*/, wchar_t* /*argv*/[]) {
-    ComInitialize com(COINIT_MULTITHREADED);
+    // initialize COM early for programmatic COM security
+    _AtlModule.InitializeCom();
+
+    // Disable COM security to allow any client to connect.
+    // WARNING: Enables non-admin clients to connect to a server running with admin privileges.
+    HRESULT hr = CoInitializeSecurity(nullptr, -1/*auto*/, nullptr, NULL/*reserved*/,
+        RPC_C_AUTHN_LEVEL_DEFAULT, ///< 
+        RPC_C_IMP_LEVEL_IDENTIFY,  ///< allow server to identify but not impersonate client
+        nullptr, EOAC_NONE/*capabilities*/, NULL/*reserved*/);
+    if (FAILED(hr))
+        abort();
 
     return _AtlModule.WinMain(SW_SHOWDEFAULT);
 }

--- a/MyServerCs/Program.cs
+++ b/MyServerCs/Program.cs
@@ -26,7 +26,7 @@ namespace MyServerCs
                     Guid typeLib = TypeLib.Register(exePath);
                     LocalServer.Register(typeof(MyInterfaces.MyServerClass).GUID, exePath, typeLib);
 #if ENABLE_RUN_AS
-                    AppID.Register(typeof(MyInterfaces.MyServerClass).GUID, "Interactive User");
+                    AppID.Register(typeof(MyInterfaces.MyServerClass).GUID, "nt authority\\localservice");
 #endif
                     return;
                 }

--- a/MyServerCs/Program.cs
+++ b/MyServerCs/Program.cs
@@ -13,6 +13,11 @@ namespace MyServerCs
         [MTAThread] // or [STAThread]
         static void Main(string[] args)
         {
+            // allow lower privilege clients to connect
+            int hr = ComSecurity.CoInitializeSecurity(IntPtr.Zero, -1, IntPtr.Zero, IntPtr.Zero, RpcAuthnLevel.Default, RpcImpLevel.Identify, IntPtr.Zero, EoAuthnCap.None, IntPtr.Zero);
+            if (hr != 0) // S_OK check
+                throw new Exception("CoInitializeSecurity failed");
+
             using var consoleTrace = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleTrace);
 


### PR DESCRIPTION
Always start the MyServerCs.exe process under the [`LocalService`](https://learn.microsoft.com/en-us/windows/win32/services/localservice-account) admin account if `ENABLE_RUN_AS` is defined. Combine with extending the C++ and C# COM servers to allow lower privilege clients to connect.

![image](https://github.com/forderud/ComSamples/assets/2671400/4ba17c64-0169-442c-a79f-63a83e260880)
