### PR TITLE
WinRT: Replace "object count" check-loop with shutdown event

### DIFF
--- a/MyExeServerWinRt/Main.cpp
+++ b/MyExeServerWinRt/Main.cpp
@@ -23,15 +23,16 @@ int wmain(int argc, wchar_t* argv[]) {
         }
     }
 
+    LifetimeTracker::Initialize();
+
     // register class factory in current process
     DWORD registration = 0;
     winrt::check_hresult(::CoRegisterClassObject(__uuidof(MyServer), winrt::make<ClassFactory<MyServerImpl>>().get(), CLSCTX_LOCAL_SERVER, REGCLS_MULTIPLEUSE, &registration));
 
     wprintf(L"Waiting for COM class creation requests...\n");
 
-    // sleep until an object has been created and the object count (except class factory) drops back to zero
-    while (!MyServerImpl::IsCreated() || (winrt::get_module_lock() > 1))
-        Sleep(1000);
+    // wait until object count drops to zero
+    LifetimeTracker::WaitForShutdown();
 
     winrt::uninit_apartment(); // will decrement get_module_lock()
     return 0;

--- a/support/WinRtUtils.hpp
+++ b/support/WinRtUtils.hpp
@@ -42,25 +42,42 @@ public:
 };
 
 
-/** Support class for controlling EXE process lifetime together with winrt::get_module_lock(). */
+/** Support class for controlling EXE process lifetime.
+    winrt::get_module_lock() does unfortunately not suffice due to https://github.com/microsoft/cppwinrt/issues/1493 */
 class LifetimeTracker {
 public:
     LifetimeTracker() {
-        s_created = true;
+        s_obj_count++;
     }
 
     ~LifetimeTracker() {
+        uint32_t new_count = --s_obj_count;
+        if (!new_count && s_shutdown)
+            SetEvent(s_shutdown); // signal shutdown
     }
 
-    /** Returns true if an object have been created. */
-    static bool IsCreated() {
-        return s_created;
+    /** Must be called before CoRegisterClassObject. */
+    static void Initialize() {
+        s_shutdown = CreateEventW(NULL, false, false, NULL);
+    }
+
+    /** Wait until the COM object count drops to zero. */
+    static void WaitForShutdown() {
+        // wait until object count drops to zero
+        WaitForSingleObject(s_shutdown, INFINITE);
+
+        // clean up
+        CloseHandle(s_shutdown);
+        s_shutdown = 0;
     }
 
 private:
-    static inline std::atomic<bool> s_created = false;
+    static std::atomic<uint32_t> s_obj_count;
+    static HANDLE                s_shutdown;
 };
 
+std::atomic<uint32_t> LifetimeTracker::s_obj_count = 0;
+HANDLE                LifetimeTracker::s_shutdown = 0;
 
 /** COM type library (un)registration function. */
 ::GUID RegisterTypeLibrary(bool do_register, std::wstring tlb_path) {


### PR DESCRIPTION
Based on the corresponding ATL implementation.


## ATL source listing

Object destruction call stack:
```
MyExeServerAtl.exe!ATL::CAtlExeModuleT<MyserverModule>::Unlock() Line 3623	C++
MyExeServerAtl.exe!ATL::ModuleLockHelper::~ModuleLockHelper() Line 3273	C++
MyExeServerAtl.exe!ATL::CComObject<MyServerImpl>::Release() Line 3315	C++
```
From `atlbase.h` line 3607:
```
LONG Lock() throw() {
    return CoAddRefServerProcess();
}

LONG Unlock() throw() {
    LONG lRet = CoReleaseServerProcess();
    if (lRet == 0) {
        if (m_bDelayShutdown) {
            m_bActivity = true;
            ::SetEvent(m_hEventShutdown); // tell monitor that we transitioned to zero
        } else {
            ::PostThreadMessage(m_dwMainThreadID, WM_QUIT, 0, 0);
        }
    }
    return lRet;
}
```

From `atlbase.h` line 3637:
```
void MonitorShutdown() throw()
{
    ::WaitForSingleObject(m_hEventShutdown, INFINITE);
    ::CloseHandle(m_hEventShutdown);
    m_hEventShutdown = NULL;
    ::PostThreadMessage(m_dwMainThreadID, WM_QUIT, 0, 0);
}
```

The `WM_QUIT` causes the `RunMessageLoop()` function to return.

From `atlbase.h` line 3853:
```
void RunMessageLoop() throw() {
    MSG msg;
    while (GetMessage(&msg, 0, 0, 0) > 0) {
        TranslateMessage(&msg);
        DispatchMessage(&msg);
    }
}
```