### PR TITLE
MyExeServerWinRt: Replace custom LifetimeTracker with wil::notifiable_module_lock

### DIFF
--- a/MyExeServerWinRt/MyExeServerWinRt.vcxproj
+++ b/MyExeServerWinRt/MyExeServerWinRt.vcxproj
@@ -96,6 +96,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -103,6 +104,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
   <Target Name="ServerUsage" AfterTargets="Build" DependsOnTargets="AssignTargetPaths">
     <Message Importance="High" Text="%0a**************************************%0a*** $(MSBuildProjectName) usage instructions ***%0a**************************************" />

--- a/MyExeServerWinRt/MyServerImpl.hpp
+++ b/MyExeServerWinRt/MyServerImpl.hpp
@@ -7,7 +7,7 @@ using namespace MyInterfaces;
 
 
 /** Non-creatable COM class that doesn't need any CLSID. */
-class NumberCruncher : public winrt::implements<NumberCruncher, INumberCruncher, winrt::no_weak_ref>, public LifetimeTracker {
+class NumberCruncher : public winrt::implements<NumberCruncher, INumberCruncher, winrt::no_weak_ref> {
 public:
     NumberCruncher() {
 #ifndef NDEBUG
@@ -32,7 +32,7 @@ public:
 
 
 /** Creatable COM class that needs a CLSID. */
-class MyServerImpl : public winrt::implements<MyServerImpl, IMyServer, winrt::no_weak_ref>, public LifetimeTracker {
+class MyServerImpl : public winrt::implements<MyServerImpl, IMyServer, winrt::no_weak_ref> {
 public:
     MyServerImpl() {
 #ifndef NDEBUG

--- a/MyExeServerWinRt/packages.config
+++ b/MyExeServerWinRt/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Pull in a https://github.com/microsoft/wil dependency to get rid of the ad-hoc `LifetimeTracker` class. It will also enable removal of the custom `ClassFactory` class in a later PR.

Based on sample code on https://github.com/microsoft/wil/blob/master/tests/CppWinRTComServerTests.cpp