### PR TITLE
WinRT: Replace custom ClassFactory with WIL CppWinRTClassFactory

### DIFF
--- a/MyDllServerWinRt/Main.cpp
+++ b/MyDllServerWinRt/Main.cpp
@@ -1,6 +1,7 @@
 #include <Windows.h>
 #include <unknwn.h>
 #include <winrt/Windows.Foundation.h>
+#include <wil/cppwinrt_register_com_server.h>
 #include "../support/WinRtUtils.hpp"
 #include "../MyExeServerWinRt/MyServerImpl.hpp"
 
@@ -32,8 +33,8 @@ STDAPI DllGetClassObject(::GUID const& clsid, ::GUID const& iid, void** result) 
     *result = nullptr;
 
     if (clsid == __uuidof(MyServer)) {
-        // TODO: Replace with wil::details::CppWinRTClassFactory after https://github.com/microsoft/wil/issues/534 is resolved
-        return winrt::make<ClassFactory<MyServerImpl>>().as(iid, result);
+        // TODO: Avoid relying on an "internal" WIL class here (see https://github.com/microsoft/wil/issues/534)
+        return winrt::make<wil::details::CppWinRTClassFactory<MyServerImpl>>().as(iid, result);
     }
 
     return CLASS_E_CLASSNOTAVAILABLE;

--- a/MyDllServerWinRt/MyDllServerWinRt.vcxproj
+++ b/MyDllServerWinRt/MyDllServerWinRt.vcxproj
@@ -101,6 +101,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="ServerUsage" AfterTargets="Build" DependsOnTargets="AssignTargetPaths">
     <Message Importance="High" Text="%0a**************************************%0a*** $(MSBuildProjectName) usage instructions ***%0a**************************************" />
@@ -114,5 +115,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/MyDllServerWinRt/packages.config
+++ b/MyDllServerWinRt/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
 </packages>

--- a/MyExeServerWinRt/Main.cpp
+++ b/MyExeServerWinRt/Main.cpp
@@ -4,6 +4,7 @@
 #define WINRT_CUSTOM_MODULE_LOCK
 #include <wil/resource.h>
 #include <wil/cppwinrt_notifiable_module_lock.h>
+#include <wil/cppwinrt_register_com_server.h>
 
 #include "../support/WinRtUtils.hpp"
 #include "MyServerImpl.hpp"
@@ -40,9 +41,8 @@ int wmain(int argc, wchar_t* argv[]) {
         });
 
     // register class factory in current process
-    // TODO: Replace with wil::register_com_server after https://github.com/microsoft/wil/pull/533 is fixed.
-    DWORD registration = 0;
-    winrt::check_hresult(::CoRegisterClassObject(__uuidof(MyServer), winrt::make<ClassFactory<MyServerImpl>>().get(), CLSCTX_LOCAL_SERVER, REGCLS_MULTIPLEUSE, &registration));
+    // TODO: Fix buggy wil::register_com_server implementation (see https://github.com/microsoft/wil/pull/533)
+    auto revoker = wil::register_com_server<MyServerImpl>(); // registers with CLSCTX_LOCAL_SERVER, REGCLS_MULTIPLEUSE
 
     wprintf(L"Waiting for COM class creation requests...\n");
 

--- a/MyExeServerWinRt/MyServerImpl.hpp
+++ b/MyExeServerWinRt/MyServerImpl.hpp
@@ -32,7 +32,8 @@ public:
 
 
 /** Creatable COM class that needs a CLSID. */
-class MyServerImpl : public winrt::implements<MyServerImpl, IMyServer, winrt::no_weak_ref> {
+class __declspec(uuid("AF080472-F173-4D9D-8BE7-435776617347")) // __uuidof(MyServer)
+MyServerImpl : public winrt::implements<MyServerImpl, IMyServer, winrt::no_weak_ref> {
 public:
     MyServerImpl() {
 #ifndef NDEBUG

--- a/support/WinRtUtils.hpp
+++ b/support/WinRtUtils.hpp
@@ -10,38 +10,6 @@
 #include "../support/CurrentModule.hpp"
 
 
-/** Minimal COM class factory implementation.
-    TODO: Replace with wil::detail::CppWinRTClassFactory after https://github.com/microsoft/wil/pull/533 and https://github.com/microsoft/wil/issues/534 are resolved. */
-template <class T>
-class ClassFactory : public winrt::implements<ClassFactory<T>, IClassFactory, winrt::no_module_lock> {
-public:
-    ClassFactory() {
-#ifndef NDEBUG
-        wprintf(L"ClassFactory ctor\n");
-#endif
-    }
-
-    ~ClassFactory() {
-#ifndef NDEBUG
-        wprintf(L"ClassFactory dtor\n");
-#endif
-    }
-
-    HRESULT CreateInstance(IUnknown* outer, const IID& iid, void** result) noexcept override {
-        *result = nullptr;
-        if (outer)
-            return CLASS_E_NOAGGREGATION; // aggregation not supported yet
-
-        // create object
-        return winrt::make<T>().as(iid, result);
-    }
-
-    HRESULT LockServer(BOOL) noexcept override {
-        return S_OK;
-    }
-};
-
-
 /** COM type library (un)registration function.
     TODO: Replace this function with WIL alternative if https://github.com/microsoft/wil/issues/531 is resolved. */
 ::GUID RegisterTypeLibrary(bool do_register, std::wstring tlb_path) {


### PR DESCRIPTION
Underlying implementation: https://github.com/microsoft/wil/blob/master/include/wil/cppwinrt_register_com_server.h


**PROBLEM**: `wil::register_com_server` doesn't seem to pick up the COM class ID as intended. It instead detects the COM _interface_ GUID when calling `CoRegisterClassObject`.

### Upstream issue reports
* WIL bugfix: https://github.com/microsoft/wil/pull/537
* WIL enhancement request: https://github.com/microsoft/wil/issues/534

## COM class GUID implementation notes
```
namespace winrt::impl
    template <typename T>
    inline constexpr guid guid_v{ __uuidof(T) };

    template <typename T, typename = std::void_t<>>
    struct default_interface
    {
        using type = T;
    };
}

WINRT_EXPORT namespace winrt
{
    template <typename T>
    using default_interface = typename impl::default_interface<T>::type;

    template <typename T>
    constexpr guid const& guid_of() noexcept
    {
        return impl::guid_v<default_interface<T>>;
    }
}
``` 
